### PR TITLE
Update 'David Darnes' author social links

### DIFF
--- a/src/site/_data/authorsData.json
+++ b/src/site/_data/authorsData.json
@@ -1686,6 +1686,10 @@
   },
   "daviddarnes": {
     "country": "UK",
+    "homepage": "https://darn.es/",
+    "mastodon": "https://mastodon.design/@daviddarnes",
+    "github": "DavidDarnes",
+    "linkedin": "https://www.linkedin.com/in/daviddarnes/",
     "twitter": "DavidDarnes",
     "image": "image/kheDArv5csY6rvQUJDbWRscckLr1/D4RF9eRlpsL0byFo3nTu.jpeg"
   },


### PR DESCRIPTION
Changes proposed in this pull request:
- Added social links to authorsData.json for 'daviddarnes' id

Realised I only had Twitter showing on my author details here, so thought I'd add some more reliable links 😁

